### PR TITLE
Use native `bigint` in ReScript-v11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   "author": "Justin Magaram",
   "license": "ISC",
   "dependencies": {
-    "@rescript/core": "^1.1.0",
-    "rescript": "^11.0.1",
+    "@rescript/core": "^1.3.0",
+    "rescript": "^11.1.0",
     "rescript-schema": "^6.4.0"
   },
   "files": [

--- a/src/Extras__Unknown.res
+++ b/src/Extras__Unknown.res
@@ -17,7 +17,7 @@ external typeof: 'a => typeof = "#typeof"
 
 type object
 type function
-type bigInt = BigInt.t
+type bigInt = bigint
 type symbol = Symbol.t
 
 // typeof null == "object". Gotta love that! Do better here.

--- a/src/Extras__Unknown.resi
+++ b/src/Extras__Unknown.resi
@@ -41,7 +41,7 @@ external typeof: 'a => typeof = "#typeof"
 
 type object
 type function
-type bigInt = BigInt.t
+type bigInt = bigint
 type symbol = Symbol.t
 
 /**


### PR DESCRIPTION
fixes #3 